### PR TITLE
68 MyBatis 설정 확인

### DIFF
--- a/src/main/java/io/github/mygoodsupporter/dao/MemberDAO.java
+++ b/src/main/java/io/github/mygoodsupporter/dao/MemberDAO.java
@@ -2,13 +2,9 @@ package io.github.mygoodsupporter.dao;
 
 import io.github.mygoodsupporter.domain.Authority;
 import io.github.mygoodsupporter.domain.Member;
-import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.annotations.Mapper;
-import org.mybatis.spring.SqlSessionTemplate;
-import org.springframework.stereotype.Repository;
 
 @Mapper
-@Repository
 public interface MemberDAO {
 
 	int insertMember(Member member);

--- a/src/main/java/io/github/mygoodsupporter/dao/ProjectDAO.java
+++ b/src/main/java/io/github/mygoodsupporter/dao/ProjectDAO.java
@@ -2,12 +2,10 @@ package io.github.mygoodsupporter.dao;
 
 import io.github.mygoodsupporter.domain.Project;
 import org.apache.ibatis.annotations.Mapper;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Mapper
-@Repository
 public interface ProjectDAO {
 
     List<Project> getProjects();

--- a/src/main/java/io/github/mygoodsupporter/dao/ProposalMapper.java
+++ b/src/main/java/io/github/mygoodsupporter/dao/ProposalMapper.java
@@ -2,12 +2,10 @@ package io.github.mygoodsupporter.dao;
 
 import io.github.mygoodsupporter.domain.Proposal;
 import org.apache.ibatis.annotations.Mapper;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Mapper
-@Repository
 public interface ProposalMapper {
 
     List<Proposal> getProposals();


### PR DESCRIPTION
**작성 중 내일 작성할꺼임..**
MyBatis 설정이 제대로 되어있나 확인했습니다.

1. 매퍼인터페이스에서 @Repository 어노테이션 제거
spring-mvc만 사용할 때는 @Repository 어노테이션을 붙여야 컴파일 타임에도 의존성 정보가 제대로 표시됐었습니다.
springboot를 사용하면 mybatis-spring-boot-autoconfigure 라이브러리로 mybatis 설정을 도와줘서 매퍼인터페이스도 빈으로 자동 등록해줍니다. 


2. 데이터의 원자성
하나의 객체가 생성되거나 변경될 때 

